### PR TITLE
Improve memory consumption by cleaning up garbage references

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
     	"php": ">=5.3",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
-        "react/promise": "~2.1|~1.2",
-        "react/promise-timer": "~1.0"
+        "react/promise": "^2.7 || ^1.2.1",
+        "react/promise-timer": "^1.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"

--- a/tests/FunctionAwaitAllTest.php
+++ b/tests/FunctionAwaitAllTest.php
@@ -104,4 +104,28 @@ class FunctionAwaitAllTest extends TestCase
             $this->assertTrue($cancelled);
         }
     }
+
+    /**
+     * @requires PHP 7
+     */
+    public function testAwaitAllPendingPromiseWithTimeoutAndCancellerShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $promise = new \React\Promise\Promise(function () { }, function () {
+            throw new RuntimeException();
+        });
+        try {
+            Block\awaitAll(array($promise), $this->loop, 0.001);
+        } catch (Exception $e) {
+            // no-op
+        }
+        unset($promise, $e);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
 }


### PR DESCRIPTION
While debugging some very odd memory issues in a live application, I noticed that this component shows some unexpected memory consumption and memory would not immediately be freed as expected. Let's not call this a "memory leak", because memory was eventually freed, but this clearly caused some unexpected and significant memory growth.

This builds on top of the work done in https://github.com/reactphp/promise/pull/113, https://github.com/reactphp/promise/pull/115, https://github.com/reactphp/promise/pull/116 and https://github.com/reactphp/promise/pull/117 and https://github.com/reactphp/promise-timer/pull/33.

I'm marking this PR as WIP because this includes a test for https://github.com/reactphp/promise/pull/124 which is yet to be released as part of react/promise v2.7.0. Once this release is out, I'll update the version reference and this should be ready to be shipped.