### PR TITLE
await: get_class() expects param 1 to be object

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -87,7 +87,7 @@ function await(PromiseInterface $promise, LoopInterface $loop, $timeout = null)
     if ($rejected) {
         if (!$exception instanceof \Exception) {
             $exception = new \UnexpectedValueException(
-                'Promise rejected with unexpected value of type ' . (is_object(($exception) ? get_class($exception) : gettype($exception))),
+                'Promise rejected with unexpected value of type ' . (is_object($exception) ? get_class($exception) : gettype($exception)),
                 0,
                 $exception instanceof \Throwable ? $exception : null
             );

--- a/tests/FunctionAwaitTest.php
+++ b/tests/FunctionAwaitTest.php
@@ -53,6 +53,18 @@ class FunctionAwaitTest extends TestCase
         }
     }
 
+    /**
+     * @expectedException UnexpectedValueException
+     * @expectedExceptionMessage type string
+     */
+    public function testAwaitRejectedWithStringGivesUnexpectedValueException()
+    {
+        $promise = Promise\reject('Test');
+
+        Block\await($promise, $this->loop);
+        $this->fail();
+    }
+
     public function testAwaitOneResolved()
     {
         $promise = $this->createPromiseResolved(2);


### PR DESCRIPTION
A promise rejected with a non-object causes await() to fail badly, reason
are wrong parenthesis for is_object()