### PR TITLE
Check if the function is declared before declaring it.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "autoload": {
-        "files": [ "src/functions.php" ]
+        "files": [ "src/functions_include.php" ]
     },
     "require": {
     	"php": ">=5.3",

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Clue\React\Block;
+
+if (!function_exists('Clue\\React\\Block\\sleep')) {
+    require __DIR__ . '/functions.php';
+}
+


### PR DESCRIPTION
In case you use pthreads or something else related to threading you might encounter this issue. It happens only with functions and is fixable only by adding these checks. Another way to avoid this is to wrap functions as static into classes.