### PR TITLE
Fix is_object() check on rejections with truthy non-Exception values

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -87,7 +87,7 @@ function await(PromiseInterface $promise, LoopInterface $loop, $timeout = null)
     if ($rejected) {
         if (!$exception instanceof \Exception) {
             $exception = new \UnexpectedValueException(
-                'Promise rejected with unexpected value of type ' . (is_object(($exception) ? get_class($exception) : gettype($exception))),
+                'Promise rejected with unexpected value of type ' . (is_object($exception) ? get_class($exception) : gettype($exception)),
                 0,
                 $exception instanceof \Throwable ? $exception : null
             );

--- a/tests/FunctionAwaitTest.php
+++ b/tests/FunctionAwaitTest.php
@@ -30,6 +30,20 @@ class FunctionAwaitTest extends TestCase
     /**
      * @expectedException UnexpectedValueException
      */
+    public function testAwaitOneRejectedWithNonFalsyWillWrapInUnexpectedValueException()
+    {
+        $all = array(
+            $this->createPromiseResolved(1),
+            Promise\reject(new Exception('first')),
+            Promise\reject(new Exception('second'))
+        );
+
+        Block\await(Promise\some($all, count($all)), $this->loop);
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
     public function testAwaitOneRejectedWithNullWillWrapInUnexpectedValueException()
     {
         $promise = Promise\reject(null);


### PR DESCRIPTION
When `React\Promise\some()` returns an array of Exceptions as the resolved value, then `Block\await` fails on that promise. Turns out this bug bypassed all tests because `$exception` was always tested with falsy values, so `($exception) ? get_class($exception) : gettype($exception)` was passing anyway. But when `$exception` is a non empty array (of Exceptions), this bug emerges.