### PR TITLE
Run tests on PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
@@ -20,7 +20,8 @@ matrix:
     - php: hhvm-3.18
 
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,6 @@
         "react/promise-timer": "^1.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<phpunit bootstrap="vendor/autoload.php" 
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Block React Test Suite">
             <directory>./tests/</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" 
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
          cacheResult="false">
     <testsuites>
@@ -8,9 +11,9 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Block React Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/FunctionAwaitAllTest.php
+++ b/tests/FunctionAwaitAllTest.php
@@ -23,10 +23,6 @@ class FunctionAwaitAllTest extends TestCase
         $this->assertEquals(array('first' => 1, 'second' => 2), Block\awaitAll($all, $this->loop));
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage test
-     */
     public function testAwaitAllRejected()
     {
         $all = array(
@@ -34,12 +30,10 @@ class FunctionAwaitAllTest extends TestCase
             $this->createPromiseRejected(new \Exception('test'))
         );
 
+        $this->setExpectedException('Exception', 'test');
         Block\awaitAll($all, $this->loop);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testAwaitAllRejectedWithFalseWillWrapInUnexpectedValueException()
     {
         $all = array(
@@ -47,13 +41,10 @@ class FunctionAwaitAllTest extends TestCase
             Promise\reject(false)
         );
 
+        $this->setExpectedException('UnexpectedValueException');
         Block\awaitAll($all, $this->loop);
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage first
-     */
     public function testAwaitAllOnlyRejected()
     {
         $all = array(
@@ -61,6 +52,7 @@ class FunctionAwaitAllTest extends TestCase
             $this->createPromiseRejected(new \Exception('second'))
         );
 
+        $this->setExpectedException('Exception', 'first');
         Block\awaitAll($all, $this->loop);
     }
 

--- a/tests/FunctionAwaitAnyTest.php
+++ b/tests/FunctionAwaitAnyTest.php
@@ -9,11 +9,9 @@ use Clue\React\Block;
 
 class FunctionAwaitAnyTest extends TestCase
 {
-    /**
-     * @expectedException UnderflowException
-     */
     public function testAwaitAnyEmpty()
     {
+        $this->setExpectedException('UnderflowException');
         Block\awaitAny(array(), $this->loop);
     }
 
@@ -49,9 +47,6 @@ class FunctionAwaitAnyTest extends TestCase
         $this->assertEquals(2, Block\awaitAny($all, $this->loop));
     }
 
-    /**
-     * @expectedException UnderflowException
-     */
     public function testAwaitAnyAllRejected()
     {
         $all = array(
@@ -59,6 +54,7 @@ class FunctionAwaitAnyTest extends TestCase
             $this->createPromiseRejected(2)
         );
 
+        $this->setExpectedException('UnderflowException');
         Block\awaitAny($all, $this->loop);
     }
 

--- a/tests/FunctionAwaitTest.php
+++ b/tests/FunctionAwaitTest.php
@@ -8,36 +8,27 @@ use Clue\React\Block;
 
 class FunctionAwaitTest extends TestCase
 {
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage test
-     */
     public function testAwaitOneRejected()
     {
         $promise = $this->createPromiseRejected(new \Exception('test'));
 
+        $this->setExpectedException('Exception', 'test');
         Block\await($promise, $this->loop);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     * @expectedExceptionMessage Promise rejected with unexpected value of type bool
-     */
     public function testAwaitOneRejectedWithFalseWillWrapInUnexpectedValueException()
     {
         $promise = Promise\reject(false);
 
+        $this->setExpectedException('UnexpectedValueException', 'Promise rejected with unexpected value of type bool');
         Block\await($promise, $this->loop);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     * @expectedExceptionMessage Promise rejected with unexpected value of type NULL
-     */
     public function testAwaitOneRejectedWithNullWillWrapInUnexpectedValueException()
     {
         $promise = Promise\reject(null);
 
+        $this->setExpectedException('UnexpectedValueException', 'Promise rejected with unexpected value of type NULL');
         Block\await($promise, $this->loop);
     }
 
@@ -73,13 +64,11 @@ class FunctionAwaitTest extends TestCase
         $this->assertEquals(2, Block\await($promise, $this->loop));
     }
 
-    /**
-     * @expectedException React\Promise\Timer\TimeoutException
-     */
     public function testAwaitOncePendingWillThrowOnTimeout()
     {
         $promise = new Promise\Promise(function () { });
 
+        $this->setExpectedException('React\Promise\Timer\TimeoutException');
         Block\await($promise, $this->loop, 0.001);
     }
 

--- a/tests/FunctionSleepTest.php
+++ b/tests/FunctionSleepTest.php
@@ -12,7 +12,7 @@ class FunctionSleepTest extends TestCase
         Block\sleep(0.2, $this->loop);
         $time = microtime(true) - $time;
 
-        $this->assertEquals(0.2, $time, '', 0.1);
+        $this->assertEqualsDelta(0.2, $time, 0.1);
     }
 
     public function testSleepSmallTimerWillBeCappedReasonably()
@@ -21,6 +21,6 @@ class FunctionSleepTest extends TestCase
         Block\sleep(0.0000001, $this->loop);
         $time = microtime(true) - $time;
 
-        $this->assertEquals(0.1, $time, '', 0.1);
+        $this->assertEqualsDelta(0.1, $time, 0.1);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,7 +9,10 @@ class TestCase extends BaseTestCase
 {
     protected $loop;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpLoop()
     {
         $this->loop = \React\EventLoop\Factory::create();
     }
@@ -42,5 +45,33 @@ class TestCase extends BaseTestCase
         $loop->addTimer($delay, function () use ($loop) {
             $loop->stop();
         });
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
+
+    public function assertEqualsDelta($expected, $actual, $delta)
+    {
+        if (method_exists($this, 'assertEqualsWithDelta')) {
+            // PHPUnit 7.5+
+            $this->assertEqualsWithDelta($expected, $actual, $delta);
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 7.5
+            $this->assertEquals($expected, $actual, '', $delta);
+        }
     }
 }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta1-cli php vendor/bin/phpunit
PHPUnit 9.3.7 by Sebastian Bergmann and contributors.

...................................                               35 / 35 (100%)

Time: 00:00.369, Memory: 6.00 MB

OK (35 tests, 44 assertions)

```
