### PR TITLE
await: throw Throwables

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -117,15 +117,16 @@ function await(PromiseInterface $promise, LoopInterface $loop, $timeout = null)
     }
 
     if ($rejected) {
-        if (!$exception instanceof \Exception) {
-            $exception = new \UnexpectedValueException(
-                'Promise rejected with unexpected value of type ' . (is_object($exception) ? get_class($exception) : gettype($exception)),
-                0,
-                $exception instanceof \Throwable ? $exception : null
-            );
+        if ($exception instanceof \Throwable || $exception instanceof \Exception) {
+            throw $exception;
         }
 
-        throw $exception;
+        throw new \UnexpectedValueException(
+            'Promise rejected with unexpected value of type '
+                . (is_object($exception)
+                ? get_class($exception)
+                : gettype($exception))
+        );
     }
 
     return $resolved;

--- a/tests/FunctionAwaitTest.php
+++ b/tests/FunctionAwaitTest.php
@@ -35,17 +35,15 @@ class FunctionAwaitTest extends TestCase
     /**
      * @requires PHP 7
      */
-    public function testAwaitOneRejectedWithPhp7ErrorWillWrapInUnexpectedValueExceptionWithPrevious()
+    public function testAwaitOneRejectedWithPhp7ErrorWillThrowThatVerySameError()
     {
         $promise = Promise\reject(new \Error('Test'));
 
         try {
             Block\await($promise, $this->loop);
             $this->fail();
-        } catch (\UnexpectedValueException $e) {
-            $this->assertEquals('Promise rejected with unexpected value of type Error', $e->getMessage());
-            $this->assertInstanceOf('Throwable', $e->getPrevious());
-            $this->assertEquals('Test', $e->getPrevious()->getMessage());
+        } catch (\Error $e) {
+            $this->assertEquals('Test', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
react/promise supports Throwables and so should await(). Nested exceptions
make it trickier to track down the root cause of a failing promise-ized
construct