### PR TITLE
Added support for ReactPHP Promise v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
-        "react/promise": "^2.7 || ^1.2.1",
+        "react/promise": "dev-master as 2.9.9",
         "react/promise-timer": "^1.5"
     },
     "require-dev": {

--- a/src/functions.php
+++ b/src/functions.php
@@ -283,7 +283,7 @@ function awaitAll(array $promises, LoopInterface $loop, $timeout = null)
 function _cancelAllPromises(array $promises)
 {
     foreach ($promises as $promise) {
-        if ($promise instanceof CancellablePromiseInterface) {
+        if ($promise instanceof CancellablePromiseInterface || (is_callable([$promise, 'cancel']) && $promise instanceof PromiseInterface)) {
             $promise->cancel();
         }
     }

--- a/tests/FunctionAwaitAllTest.php
+++ b/tests/FunctionAwaitAllTest.php
@@ -34,8 +34,10 @@ class FunctionAwaitAllTest extends TestCase
         Block\awaitAll($all, $this->loop);
     }
 
-    public function testAwaitAllRejectedWithFalseWillWrapInUnexpectedValueException()
+    public function testAwaitAllRejectedWithExceptionWillWrapInUnexpectedValueException()
     {
+        $this->skipForPromise3();
+
         $all = array(
             $this->createPromiseResolved(1),
             Promise\reject(false)

--- a/tests/FunctionAwaitAnyTest.php
+++ b/tests/FunctionAwaitAnyTest.php
@@ -18,7 +18,7 @@ class FunctionAwaitAnyTest extends TestCase
     public function testAwaitAnyFirstResolved()
     {
         $all = array(
-            $this->createPromiseRejected(1),
+            $this->createPromiseRejected(new \Exception(1)),
             $this->createPromiseResolved(2, 0.01),
             $this->createPromiseResolved(3, 0.02)
         );
@@ -33,7 +33,7 @@ class FunctionAwaitAnyTest extends TestCase
         $d3 = new Deferred();
 
         $this->loop->addTimer(0.01, function() use ($d1, $d2, $d3) {
-            $d1->reject(1);
+            $d1->reject(new \Exception(1));
             $d2->resolve(2);
             $d3->resolve(3);
         });
@@ -50,8 +50,8 @@ class FunctionAwaitAnyTest extends TestCase
     public function testAwaitAnyAllRejected()
     {
         $all = array(
-            $this->createPromiseRejected(1),
-            $this->createPromiseRejected(2)
+            $this->createPromiseRejected(new \Exception(1)),
+            $this->createPromiseRejected(new \Exception(2))
         );
 
         $this->setExpectedException('UnderflowException');

--- a/tests/FunctionAwaitTest.php
+++ b/tests/FunctionAwaitTest.php
@@ -18,6 +18,7 @@ class FunctionAwaitTest extends TestCase
 
     public function testAwaitOneRejectedWithFalseWillWrapInUnexpectedValueException()
     {
+        $this->skipForPromise3();
         $promise = Promise\reject(false);
 
         $this->setExpectedException('UnexpectedValueException', 'Promise rejected with unexpected value of type bool');
@@ -26,6 +27,7 @@ class FunctionAwaitTest extends TestCase
 
     public function testAwaitOneRejectedWithNullWillWrapInUnexpectedValueException()
     {
+        $this->skipForPromise3();
         $promise = Promise\reject(null);
 
         $this->setExpectedException('UnexpectedValueException', 'Promise rejected with unexpected value of type NULL');
@@ -153,6 +155,7 @@ class FunctionAwaitTest extends TestCase
 
     public function testAwaitNullValueShouldNotCreateAnyGarbageReferences()
     {
+        $this->skipForPromise3();
         if (class_exists('React\Promise\When') && PHP_VERSION_ID >= 50400) {
             $this->markTestSkipped('Not supported on legacy Promise v1 API with PHP 5.4+');
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,19 @@ class TestCase extends BaseTestCase
         $this->loop = \React\EventLoop\Factory::create();
     }
 
+    /**
+     * Skips a test if the test suite is running with react/promise version
+     * 3.0 or later.
+     *
+     * @return void
+     */
+    protected function skipForPromise3()
+    {
+        if (! class_exists('React\Promise\CancellablePromiseInterface')) {
+            $this->markTestSkipped('Test is not supported/required by the Promise v3 API.');   
+        }
+    }
+
     protected function createPromiseResolved($value = null, $delay = 0.01)
     {
         $deferred = new Deferred();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,7 +25,7 @@ class TestCase extends BaseTestCase
      */
     protected function skipForPromise3()
     {
-        if (! class_exists('React\Promise\CancellablePromiseInterface')) {
+        if (! interface_exists('React\Promise\CancellablePromiseInterface')) {
             $this->markTestSkipped('Test is not supported/required by the Promise v3 API.');   
         }
     }


### PR DESCRIPTION
Currently locked the `react/promise` version at `dev-master as 2.9.9`.