### PR TITLE
Add support for throwables (>= PHP 7.0), not throwing UnexpectedValueException anymore

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -80,7 +80,7 @@ function sleep($time, LoopInterface $loop)
  * @param LoopInterface    $loop
  * @param null|float       $timeout (optional) maximum timeout in seconds or null=wait forever
  * @return mixed returns whatever the promise resolves to
- * @throws Exception when the promise is rejected
+ * @throws \Throwable when the promise is rejected
  * @throws TimeoutException if the $timeout is given and triggers
  */
 function await(PromiseInterface $promise, LoopInterface $loop, $timeout = null)
@@ -108,7 +108,7 @@ function await(PromiseInterface $promise, LoopInterface $loop, $timeout = null)
         }
     );
 
-    // Explicitly overwrite argument with null value. This ensure that this
+    // Explicitly overwrite argument with null value. This ensures that this
     // argument does not show up in the stack trace in PHP 7+ only.
     $promise = null;
 
@@ -117,12 +117,22 @@ function await(PromiseInterface $promise, LoopInterface $loop, $timeout = null)
     }
 
     if ($rejected) {
-        if (!$exception instanceof \Exception) {
-            $exception = new \UnexpectedValueException(
-                'Promise rejected with unexpected value of type ' . (is_object($exception) ? get_class($exception) : gettype($exception)),
-                0,
-                $exception instanceof \Throwable ? $exception : null
-            );
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            if (!$exception instanceof \Throwable) {
+                $exception = new \UnexpectedValueException(
+                    'Promise rejected with unexpected value of type ' . (is_object($exception) ? get_class($exception) : gettype($exception)),
+                    0,
+                    null
+                );
+            }
+        } else {
+            if (!$exception instanceof \Exception) {
+                $exception = new \UnexpectedValueException(
+                    'Promise rejected with unexpected value of type ' . (is_object($exception) ? get_class($exception) : gettype($exception)),
+                    0,
+                    null
+                );
+            }
         }
 
         throw $exception;

--- a/tests/FunctionAwaitTest.php
+++ b/tests/FunctionAwaitTest.php
@@ -35,17 +35,22 @@ class FunctionAwaitTest extends TestCase
     /**
      * @requires PHP 7
      */
-    public function testAwaitOneRejectedWithPhp7ErrorWillWrapInUnexpectedValueExceptionWithPrevious()
+    public function testAwaitOneRejectedWithPhp7Error()
     {
-        $promise = Promise\reject(new \Error('Test'));
+        $expected = new \Error('test');
+        $promise = $this->createPromiseRejected($expected);
 
+        // PHPUnit doesn't have something like setExpectedThrowable,
+        // this try catch block tests if the Error is actually thrown
+        // when calling Block\await
         try {
             Block\await($promise, $this->loop);
-            $this->fail();
-        } catch (\UnexpectedValueException $e) {
-            $this->assertEquals('Promise rejected with unexpected value of type Error', $e->getMessage());
-            $this->assertInstanceOf('Throwable', $e->getPrevious());
-            $this->assertEquals('Test', $e->getPrevious()->getMessage());
+
+            $this->fail('Expected \Error to be thrown, did not happen');
+        }
+
+        catch (\Error $error) {
+            self::assertSame($expected, $error);
         }
     }
 


### PR DESCRIPTION
I'd like to propose the change to support _Throwables_ next to _Exceptions_, so that they can be handled properly as well.

_Throwables_ within PHP are supported since PHP 7.0. Currently only _Exceptions_ are supported and _Throwables_ will lead to an _UnexpectedValueException_. With this change _Throwables_ are supported as well.

- reactphp/promise v2.7.* and v2.8.* supports any reason for a rejection, see https://github.com/reactphp/promise/blob/v2.7.1/src/Deferred.php 
- Master on reactphp/promise supports throwables explicitly: https://github.com/reactphp/promise/blob/master/src/Deferred.php#L29

Given the direction reactphp/promise goes I think it would be good to make this change.